### PR TITLE
Add blog links to Readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Estuary Flow Examples
 
-This repository is a collection of example projects utilizing Estuary Flow.
+This repository is a collection of example projects utilizing Estuary Flow. See subdirectories for specific projects and instructions.
 
-Check out the full tutorial here:
+For more, check out the Estuary [blog](https://estuary.dev/blog/) and [documentation](https://docs.estuary.dev/).

--- a/derivations-ad-performance/README.md
+++ b/derivations-ad-performance/README.md
@@ -7,3 +7,5 @@
 3. Set up Estuary Flow capture
 4. ???
 5. Profit!
+
+Watch the demo here: https://youtu.be/dbHgn-AdVzU

--- a/derivations-sql-full-outer-join/README.md
+++ b/derivations-sql-full-outer-join/README.md
@@ -8,3 +8,5 @@
 4. Deploy derivation via `flowctl`
 5. ???
 5. Profit!
+
+Read the full article here: https://estuary.dev/derivations-join-collections-sql/

--- a/estuary-bytewax/README.md
+++ b/estuary-bytewax/README.md
@@ -7,4 +7,4 @@
 3. Set up MongoDB Capture in Estuary Flow
 4. Start consuming with Dekaf.
 
-Full how-to guide: 
+Full how-to guide: https://bytewax.io/blog/estuary-flow-mongodb-bytewax-real-time-data

--- a/mongodb-pinecone-rag/README.md
+++ b/mongodb-pinecone-rag/README.md
@@ -3,4 +3,4 @@
 This projects showcases the components of a CDC data flow that streams data from
 MongoDB, vectorizes it then loads the embeddings into Pinecone.
 
-See blog post for details: 
+See blog post for details: https://estuary.dev/real-time-rag-with-estuary-and-pinecone/

--- a/postgres-measure-wal-throughput/README.md
+++ b/postgres-measure-wal-throughput/README.md
@@ -1,1 +1,5 @@
-# Measure WAL throughout in PostgreSQL
+# Measure WAL throughput in PostgreSQL
+
+Learn how to approximate change event throughput for PostgreSQL by measuring the Write-ahead-log (WAL).
+
+See blog post for details: https://estuary.dev/measuring-postgresql-wal-throughput/

--- a/postgresql-cdc-databricks-fraud-detection/README.md
+++ b/postgresql-cdc-databricks-fraud-detection/README.md
@@ -1,3 +1,5 @@
 # Real-time fraud detection with Estuary Flow & Databricks
 
-See blog post for details: 
+How to implement a real-time fraud detection pipeline with Estuary Flow and Databricks
+
+See blog post for details: https://estuary.dev/real-time-fraud-detection-databricks/

--- a/streaming-lakehouse-iceberg-duckdb/README.md
+++ b/streaming-lakehouse-iceberg-duckdb/README.md
@@ -7,3 +7,5 @@
 3. Set up Estuary Flow capture
 4. ???
 5. Profit!
+
+Read the blog post at: https://estuary.dev/building-streaming-lakehouse-flow-iceberg/


### PR DESCRIPTION
Some project Readme files were missing links to their relevant resources. This update fills out article and video links that I was able to determine.