### PR TITLE
Add Estuary + Orchestra agent-skills demo

### DIFF
--- a/estuary-orchestra-agent-pipeline/.gitignore
+++ b/estuary-orchestra-agent-pipeline/.gitignore
@@ -1,0 +1,14 @@
+# Snowflake key-pair credentials
+rsa_key.p8
+rsa_key.pub
+*.p8
+
+# dbt
+dbt/target/
+dbt/dbt_packages/
+dbt/logs/
+profiles.yml
+
+# Python
+__pycache__/
+*.pyc

--- a/estuary-orchestra-agent-pipeline/README.md
+++ b/estuary-orchestra-agent-pipeline/README.md
@@ -1,0 +1,306 @@
+# Build a Pipeline by Talking to Your Agent: Estuary + Orchestra Skills
+
+This demo builds a complete, production-shaped data pipeline **without writing
+the connectors or the orchestration by hand** — you describe what you want in
+plain English and two sets of [agent skills](https://agentskills.io) do the
+work:
+
+- **[Estuary agent skills](https://docs.estuary.dev/guides/agent-skills/)** set
+  up **ingestion** — real-time CDC from Postgres into Snowflake.
+- **[Orchestra agent skills](https://docs.getorchestra.io/docs/guides/orchestra-skills)**
+  set up **orchestration** — a scheduled dbt transform plus data-quality checks
+  on top of that Snowflake data.
+
+The result is the classic split done right: Estuary streams the raw data
+continuously in real time, and Orchestra runs the batch transform-and-validate
+layer on a schedule on top of it.
+
+The two aren't just adjacent — they're **wired together**. Orchestra has a
+native `ESTUARY` integration, so the first thing the batch pipeline does is ask
+Estuary whether ingestion is actually healthy and fresh. If the capture has
+stalled, the dbt build and every quality test **skip** instead of quietly
+rebuilding dashboards on stale data.
+
+```
+ Postgres (orders)                    ┌─ Estuary agent skills build this ─┐
+   │  inserts / updates / deletes     │                                   │
+   ▼                                  ▼                                   │
+ Estuary capture  ───►  Estuary collection  ───►  Snowflake               │
+ (source-postgres)      agent-demo/public/orders   (raw mirror)           ┘
+                                                            │
+                      ┌─ Orchestra agent skills build this ─┤
+                      ▼                                     │
+        ① ESTUARY_CHECK_FLOW  ──(healthy? fresh?)──┐         │
+              on both Estuary tasks                │         │
+                                                   ▼         ▼
+                                      ② dbt build (stg_orders,
+                                         daily_order_metrics)
+                                                   │
+                                                   ▼
+                                      ③ SNOWFLAKE_RUN_TEST × 4
+                                    (freshness, revenue, enum, future dates)
+                                         scheduled daily by Orchestra
+```
+
+## What's in this repo
+
+Everything here is either **scaffolding you run** (the source database) or an
+**example of what the agents produce** (the Flow specs, the dbt project, the
+Orchestra pipeline) so you can version-control and inspect the output.
+
+| Path | What it is | Who authors it |
+|------|------------|----------------|
+| `docker-compose.yml` | Postgres (`wal_level=logical`) + order generator | you run it |
+| `postgres/init.sql` | `orders` table + CDC prerequisites | you |
+| `generator/` | Python order generator (insert/update/delete traffic) | you |
+| `snowflake/setup.sql` | Shared Snowflake DB, role, user, warehouse | you |
+| `flow/` | Capture + Snowflake materialization specs | **Estuary skills** |
+| `dbt/` | Staging + marts models and tests over the streamed data | you (or an agent) |
+| `orchestra/daily_orders_pipeline.yaml` | Estuary gate → dbt → quality-test DAG | **Orchestra skills** |
+
+## Prerequisites
+
+- Docker, and [`ngrok`](https://ngrok.com/) (to expose local Postgres to Estuary)
+- An [Estuary account](https://dashboard.estuary.dev) and a Snowflake account
+- An [Orchestra account](https://app.getorchestra.io) + an Orchestra API key
+- **Claude Code** (or Cursor / Codex) — this is where you'll talk to the skills
+
+---
+
+## Step 0 — Install both sets of agent skills
+
+In Claude Code, add both marketplaces and install the plugins:
+
+```text
+# Estuary — ingestion
+/plugin marketplace add estuary/agent-skills
+/plugin install estuary-captures@estuary
+/plugin install estuary-materializations@estuary
+/plugin install estuary-operations@estuary
+
+# Orchestra — orchestration
+/plugin marketplace add orchestra-hq/orchestra-skills
+/plugin install orchestra@orchestra-marketplace
+```
+
+Orchestra's skills act through its MCP server, which is how the agent lists
+runs, reads logs, validates YAML, and publishes pipelines. Add it with your API
+key (Orchestra UI → Settings → Workspace):
+
+```bash
+claude mcp add orchestra https://mcp.getorchestra.io/orchestra \
+  --transport http \
+  --header "Authorization: Bearer <YOUR_ORCHESTRA_API_KEY>"
+```
+
+Restart Claude Code afterwards so the new plugins and MCP tools load.
+
+> The skills follow the open `SKILL.md` standard, so the same instructions work
+> in Cursor or Codex — see each project's docs for the copy-in setup.
+
+## Step 1 — Stand up the source
+
+Bring up Postgres (pre-configured for logical replication) and the generator
+that continuously writes orders, so there are always live changes to stream:
+
+```bash
+docker compose up -d          # Postgres + traffic generator
+ngrok tcp 5432                # note the host:port ngrok prints
+```
+
+Then create the Snowflake environment by running `snowflake/setup.sql` in a
+Snowflake worksheet. It creates `AGENT_DEMO` (with `PUBLIC` for the raw mirror
+and `ANALYTICS` for dbt output), plus the `AGENT_USER` service account and
+`AGENT_WH` warehouse used by both tools.
+
+## Step 2 — Ingestion, built by the Estuary skills
+
+Now just describe the pipeline to Claude Code. The skills run the `flowctl`
+workflow, generate the specs, and publish them. Typical prompts, in order:
+
+> **"Check that flowctl is installed and authenticated."**
+> *(`estuary-flowctl-setup` installs/authenticates the CLI)*
+
+> **"Capture my Postgres orders table into Estuary. It's reachable at the ngrok
+> address `4.tcp.ngrok.io:12345`, database `postgres`, user `flow_capture`,
+> password `secret`."**
+> *(`capture-postgres-create` runs connector discovery, then publishes the
+> capture and collection)*
+
+> **"Materialize the orders collection into Snowflake, database `AGENT_DEMO`,
+> schema `PUBLIC`, warehouse `AGENT_WH`, user `AGENT_USER` with key-pair auth."**
+> *(`materialize-snowflake-create` writes and publishes the destination spec)*
+
+> **"Is my capture healthy and is data flowing to Snowflake?"**
+> *(`estuary-task-health` / `estuary-task-stats` confirm the stream)*
+
+Within a minute or two the Snowflake table is a live mirror of the Postgres
+table, and stays in sync as the generator keeps writing.
+
+The specs the skills produce look like the ones checked in under [`flow/`](flow/).
+Two habits worth copying from them:
+
+- **Let the connector discover the schema.** Write just the `endpoint` block with
+  `bindings: []`, then `flowctl discover --source flow/capture.flow.yaml`. It
+  fills in bindings and an accurate inferred schema.
+- **Validate before publishing.** `flowctl catalog test --source …` connects to
+  the real destination and checks the config without writing anything.
+
+## Step 3 — Orchestration, built by the Orchestra skills
+
+Estuary keeps the raw data fresh; Orchestra owns the transform-and-validate
+layer on top. This repo ships a small [dbt project](dbt/) that reads the
+streamed mirror as a source and builds:
+
+- `stg_orders` — typed, cleaned staging view (Estuary lands `numeric` and
+  `timestamptz` as JSON strings, so this casts them)
+- `daily_order_metrics` — daily order counts and revenue by status
+
+Point Claude Code at it and let the Orchestra skills author and publish the DAG:
+
+> **"Create an Orchestra pipeline that first checks my Estuary capture and
+> materialization are healthy, then runs `dbt build` on the dbt project in
+> `./dbt`, then runs Snowflake data-quality tests — daily."**
+> *(`create-orchestra-pipeline` authors the YAML and validates it against the
+> real API via MCP before publishing)*
+
+> **"Add Snowflake quality tests on the marts: freshness within 24h, no null or
+> negative revenue, status values limited to the known enum, and no
+> future-dated events."**
+> *(`write-snowflake-dq-tests` profiles the tables and writes the assertions)*
+
+The result is [`orchestra/daily_orders_pipeline.yaml`](orchestra/daily_orders_pipeline.yaml).
+
+### The hinge: gating batch work on stream health
+
+Stage one is what makes the two tools a system rather than two pipelines:
+
+```yaml
+check_capture:
+  integration: ESTUARY
+  integration_job: ESTUARY_CHECK_FLOW
+  parameters:
+    task: yourprefix/agent-demo/source-postgres
+    error_threshold: 0        # any new error fails the run
+    latency_threshold: 900    # seconds since the task last published data
+```
+
+`ESTUARY_CHECK_FLOW` reads the task's OpenMetrics endpoint and compares deltas
+since the last check, so a stalled capture is caught **here** — as an explicit
+failure with everything downstream marked `SKIPPED` — rather than showing up
+days later as quietly stale dashboards.
+
+The quality tests use `SNOWFLAKE_RUN_TEST`, where each `statement` is written so
+that **returning rows means something is wrong**, and
+`error_threshold_expression: '> 0'` turns any violating row into a failure.
+
+### Connections
+
+Tasks reference credentials as `${{ ENV.* }}` environment variables — never
+inline secrets. Create three connections in the Orchestra UI under
+**Settings → Connections**, then map them to variables under **Environments**:
+
+| Connection | Variable | Needs |
+|---|---|---|
+| Estuary | `ESTUARY_CONNECTION` | An Estuary access token |
+| dbt Core | `DBT_CONNECTION` | Git repo + read token + `profiles.yml` |
+| Snowflake | `SNOWFLAKE_CONNECTION` | Account, user, key-pair, role, warehouse |
+
+Connections are **UI-only** — there is no MCP tool and no public API endpoint
+for creating them, so the agent will hand this step back to you. Wiring them to
+environment variables afterwards *can* be done by the agent (`update_environment`),
+using type `integration_credential` with the connection ID as the value.
+
+The dbt Core connection needs a little more setup:
+
+- **The dbt project must live in a Git repo** that Orchestra clones — it cannot
+  read a local directory. Push [`dbt/`](dbt/) to a repo of your own (it works
+  as-is at the repo root), and point the connection at that.
+- **A `requirements.txt` (or `pyproject.toml`) at the repo root** is required —
+  it's what Orchestra installs before running dbt. See
+  [`dbt/requirements.txt`](dbt/requirements.txt).
+- **The Git token only needs read access** to *Contents* and *Metadata*. A
+  fine-grained PAT scoped to the single repo is enough.
+- **`profiles.yml` is pasted into the connection**, not committed. Orchestra
+  stores it encrypted. Its profile name must match `dbt_project.yml` (`agent_demo`).
+
+## Step 4 — The two working in tandem
+
+That's the whole point of the demo:
+
+- **Estuary (real-time)** — the moment an order changes in Postgres, the change
+  is in the Snowflake mirror. No schedule, no polling; latency is seconds.
+- **Orchestra (scheduled batch)** — once a day, Orchestra confirms ingestion is
+  healthy, rebuilds the dbt marts over that always-fresh data, and gates them
+  behind quality checks before anyone downstream trusts them.
+
+And when the batch layer breaks, you fix it the same way you built it:
+
+> **"My Orchestra pipeline `daily_orders_analytics` failed — diagnose and fix
+> it."**
+> *(`fix-orchestra-pipeline` pulls the run's task logs over MCP, finds the root
+> cause, applies a fix, and retries; `identify-pipeline-error` stops at the
+> diagnosis if you'd rather approve the change yourself)*
+
+Other skills in the Orchestra plugin worth knowing: `account-health-check`,
+`configure-dbt-source-freshness`, `configure-dbt-build-after`,
+`orchestra-dbt-slim-ci-setup`, and `build-data-reconciliation-pipeline`.
+
+## Gotchas worth knowing
+
+This demo was built and run end-to-end; these are the things that actually bit,
+all already accounted for in the files here.
+
+**Estuary**
+
+- `source-postgres:v3` takes a nested `credentials: {auth_type, password}` block
+  and a required `historyMode` — not a flat `password`.
+- The Snowflake materialization needs `warehouse` unless the user has a default
+  one, and `private_key` (not `privateKey`).
+- **Connector configs are sops-encrypted with a MAC over the plaintext fields
+  too.** You cannot pull an existing spec, tweak `schema`, and republish — it
+  fails with `MAC mismatch`. Write a fresh config instead.
+- The Snowflake connector creates *tables*, not *schemas*. Create the target
+  schema first or the first commit fails with `Schema ... does not exist`.
+- Changing a materialization's config doesn't take effect mid-transaction: a
+  connector on a 30m sync will finish its current acknowledgement delay first.
+  Disable then re-enable shards (plus bump `backfill`) to force it immediately.
+- Keep `flowctl` current. v0.6.0 fails every publish against the current control
+  plane with `unknown field createdAt`; v0.6.12 is fine.
+
+**Orchestra**
+
+- `DBT_CORE_EXECUTE.commands` is a **single string, and a single command**.
+  Newlines are flattened, so `"dbt deps\ndbt build"` runs as
+  `dbt deps dbt build …` and dies on `No such option '--select'`.
+- You don't need `dbt deps` — Orchestra installs `packages.yml` itself first.
+- `ESTUARY_CHECK_FLOW`'s latency metric tracks commit acknowledgement, not row
+  freshness, and reads far higher than real lag (694–945s observed while
+  Snowflake was ~9s behind Postgres). Give `latency_threshold` headroom.
+- The first `ESTUARY_CHECK_FLOW` run has no baseline, so it reports the task's
+  entire failure history as new. Judge from run two.
+- Cron is six fields, **minute-first** (`0 6 ? * * *`), not seconds-first Quartz.
+- Valid alert statuses are `ANY_COMPLETED, CANCELLED, FAILED, SUCCEEDED,
+  WARNING, SKIPPED` — there's no `RUNNING_TIMEOUT`. Pipeline aliases allow only
+  letters, numbers, and underscores.
+- Validate with the `validate_pipeline` MCP tool before publishing; it catches
+  every one of the schema issues above in seconds.
+
+## Tear down
+
+```bash
+docker compose down -v            # stop Postgres + generator
+```
+
+Then disable or delete the Estuary capture/materialization (dashboard or
+`flowctl catalog delete`), pause the Orchestra pipeline, and drop the
+`AGENT_DEMO` database in Snowflake.
+
+---
+
+## Learn more
+
+- Estuary agent skills — https://docs.estuary.dev/guides/agent-skills/
+- Orchestra agent skills — https://docs.getorchestra.io/docs/guides/orchestra-skills
+- Orchestra pipeline YAML schema — https://docs.getorchestra.io/docs/core-concepts/pipelines/schema
+- Estuary docs — https://docs.estuary.dev/ · Orchestra docs — https://docs.getorchestra.io/

--- a/estuary-orchestra-agent-pipeline/README.md
+++ b/estuary-orchestra-agent-pipeline/README.md
@@ -303,4 +303,5 @@ Then disable or delete the Estuary capture/materialization (dashboard or
 - Estuary agent skills — https://docs.estuary.dev/guides/agent-skills/
 - Orchestra agent skills — https://docs.getorchestra.io/docs/guides/orchestra-skills
 - Orchestra pipeline YAML schema — https://docs.getorchestra.io/docs/core-concepts/pipelines/schema
-- Estuary docs — https://docs.estuary.dev/ · Orchestra docs — https://docs.getorchestra.io/
+- Estuary docs — https://docs.estuary.dev/
+- Orchestra docs — https://docs.getorchestra.io/

--- a/estuary-orchestra-agent-pipeline/dbt/dbt_project.yml
+++ b/estuary-orchestra-agent-pipeline/dbt/dbt_project.yml
@@ -1,0 +1,18 @@
+name: "agent_demo"
+version: "1.0.0"
+config-version: 2
+
+# The profile Orchestra's DBT_CORE task supplies at run time. Locally, define a
+# matching profile in ~/.dbt/profiles.yml (see profiles.example.yml).
+profile: "agent_demo"
+
+model-paths: ["models"]
+
+models:
+  agent_demo:
+    # The profile's schema (ANALYTICS) keeps transformed tables separate from
+    # the raw PUBLIC.ORDERS mirror Estuary maintains.
+    staging:
+      +materialized: view
+    marts:
+      +materialized: table

--- a/estuary-orchestra-agent-pipeline/dbt/models/marts/daily_order_metrics.sql
+++ b/estuary-orchestra-agent-pipeline/dbt/models/marts/daily_order_metrics.sql
@@ -1,0 +1,17 @@
+-- The demo's business-facing table: one row per day per status, with order
+-- counts and revenue. Orchestra rebuilds this daily and then runs quality
+-- checks against it before anyone downstream trusts it.
+
+with orders as (
+    select * from {{ ref('stg_orders') }}
+)
+
+select
+    cast(event_ts as date)   as order_date,
+    status,
+    count(*)                 as order_count,
+    sum(amount)              as total_amount,
+    avg(amount)              as avg_amount
+from orders
+group by 1, 2
+order by 1, 2

--- a/estuary-orchestra-agent-pipeline/dbt/models/marts/daily_order_metrics.yml
+++ b/estuary-orchestra-agent-pipeline/dbt/models/marts/daily_order_metrics.yml
@@ -1,0 +1,16 @@
+version: 2
+
+models:
+  - name: daily_order_metrics
+    description: Daily order counts and revenue, broken out by status.
+    columns:
+      - name: order_date
+        tests: [not_null]
+      - name: order_count
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: false
+      - name: total_amount
+        tests: [not_null]

--- a/estuary-orchestra-agent-pipeline/dbt/models/staging/sources.yml
+++ b/estuary-orchestra-agent-pipeline/dbt/models/staging/sources.yml
@@ -1,0 +1,23 @@
+version: 2
+
+sources:
+  - name: estuary
+    description: >
+      Raw tables kept in sync by Estuary. AGENT_DEMO.PUBLIC.ORDERS is a live
+      mirror of the operational Postgres table, updated continuously by the
+      Snowflake materialization.
+    database: AGENT_DEMO
+    schema: PUBLIC
+    tables:
+      - name: orders
+        description: One row per order, mirrored from Postgres via CDC.
+        # A freshness expectation gives dbt (and, through it, Orchestra) a way to
+        # catch a stalled capture: if no order has changed in 6 hours the source
+        # is stale, in 24 hours it's an error.
+        loaded_at_field: updated_at
+        freshness:
+          warn_after: { count: 6, period: hour }
+          error_after: { count: 24, period: hour }
+        columns:
+          - name: order_id
+            tests: [unique, not_null]

--- a/estuary-orchestra-agent-pipeline/dbt/models/staging/stg_orders.sql
+++ b/estuary-orchestra-agent-pipeline/dbt/models/staging/stg_orders.sql
@@ -1,0 +1,16 @@
+-- Cleans and types the raw orders mirror. Estuary lands numeric and timestamp
+-- fields as strings in the JSON-shaped collection, so we cast them here into
+-- the types the marts and quality checks expect.
+
+with source as (
+    select * from {{ source('estuary', 'orders') }}
+)
+
+select
+    order_id,
+    customer_name,
+    cast(amount as number(10, 2))       as amount,
+    lower(status)                       as status,
+    cast(event_ts as timestamp_ntz)     as event_ts,
+    cast(updated_at as timestamp_ntz)   as updated_at
+from source

--- a/estuary-orchestra-agent-pipeline/dbt/models/staging/stg_orders.yml
+++ b/estuary-orchestra-agent-pipeline/dbt/models/staging/stg_orders.yml
@@ -1,0 +1,19 @@
+version: 2
+
+models:
+  - name: stg_orders
+    description: Typed, cleaned one-row-per-order staging model.
+    columns:
+      - name: order_id
+        tests: [unique, not_null]
+      - name: amount
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+      - name: status
+        tests:
+          - not_null
+          - accepted_values:
+              values: ["pending", "shipped", "delivered"]

--- a/estuary-orchestra-agent-pipeline/dbt/packages.yml
+++ b/estuary-orchestra-agent-pipeline/dbt/packages.yml
@@ -1,0 +1,6 @@
+packages:
+  # Provides the accepted_range test used in models/staging/stg_orders.yml.
+  # `dbt deps` (run as the first dbt command in the Orchestra pipeline) fetches
+  # it before the build.
+  - package: dbt-labs/dbt_utils
+    version: [">=1.1.0", "<2.0.0"]

--- a/estuary-orchestra-agent-pipeline/dbt/profiles.example.yml
+++ b/estuary-orchestra-agent-pipeline/dbt/profiles.example.yml
@@ -1,0 +1,18 @@
+# Copy to ~/.dbt/profiles.yml (or point DBT_PROFILES_DIR here) to run dbt
+# locally. In production, Orchestra's DBT_CORE task injects the connection
+# defined by its Snowflake connection instead, so this file is for local runs.
+agent_demo:
+  target: dev
+  outputs:
+    dev:
+      type: snowflake
+      account: "<account>"        # e.g. ab12345.us-east-1
+      user: AGENT_USER
+      # Key-pair auth, matching snowflake/setup.sql. Point this at the private
+      # key you generated there.
+      private_key_path: "~/.ssh/rsa_key.p8"
+      role: AGENT_ROLE
+      warehouse: AGENT_WH
+      database: AGENT_DEMO
+      schema: ANALYTICS
+      threads: 4

--- a/estuary-orchestra-agent-pipeline/dbt/requirements.txt
+++ b/estuary-orchestra-agent-pipeline/dbt/requirements.txt
@@ -1,0 +1,2 @@
+dbt-core==1.8.7
+dbt-snowflake==1.8.4

--- a/estuary-orchestra-agent-pipeline/docker-compose.yml
+++ b/estuary-orchestra-agent-pipeline/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16
+    container_name: pg_agent_demo
+    command: ["postgres", "-c", "wal_level=logical"]
+    environment:
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  generator:
+    build: ./generator
+    container_name: orders_generator
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@postgres:5432/postgres
+      RATE_PER_SECOND: "2"
+    depends_on:
+      - postgres

--- a/estuary-orchestra-agent-pipeline/flow/capture.flow.yaml
+++ b/estuary-orchestra-agent-pipeline/flow/capture.flow.yaml
@@ -1,0 +1,60 @@
+# flow/capture.flow.yaml
+#
+# This is the kind of spec the Estuary `capture-postgres-create` agent skill
+# authors for you. It is included here so you can see (and version-control) the
+# result, and publish it directly if you prefer flowctl over the dashboard:
+#
+#   flowctl catalog publish --source flow/capture.flow.yaml
+#
+# Replace `yourprefix` with your Estuary tenant prefix, and set `address` to the
+# ngrok host/port that `ngrok tcp 5432` prints for you.
+#
+# Rather than hand-writing this, you can have the connector discover the tables
+# for you -- write just the `endpoint` block with `bindings: []`, then run
+# `flowctl discover --source flow/capture.flow.yaml`. Discovery fills in the
+# bindings and an accurate inferred schema, which is what the skill does.
+captures:
+  yourprefix/agent-demo/source-postgres:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-postgres:v3
+        config:
+          address: "4.tcp.ngrok.io:12345"
+          database: postgres
+          user: flow_capture
+          # historyMode: false reduces each change to the row's final state,
+          # so the destination mirrors Postgres. Set it to true to keep every
+          # individual change event instead.
+          historyMode: false
+          credentials:
+            auth_type: UserPassword
+            password: secret
+    bindings:
+      - resource:
+          namespace: public
+          stream: orders
+        target: yourprefix/agent-demo/public/orders
+
+collections:
+  yourprefix/agent-demo/public/orders:
+    key: [/order_id]
+    schema:
+      type: object
+      properties:
+        order_id:
+          type: string
+        customer_name:
+          type: string
+        # Postgres numeric and timestamptz arrive as JSON strings; the dbt
+        # staging model casts them to real types.
+        amount:
+          type: string
+        status:
+          type: string
+        event_ts:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required: [order_id]

--- a/estuary-orchestra-agent-pipeline/flow/materialization.flow.yaml
+++ b/estuary-orchestra-agent-pipeline/flow/materialization.flow.yaml
@@ -1,0 +1,45 @@
+# flow/materialization.flow.yaml
+#
+# This is the kind of spec the Estuary `materialize-snowflake-create` agent
+# skill authors for you. Publish it with:
+#
+#   flowctl catalog publish --source flow/materialization.flow.yaml
+#
+# Before publishing, validate against Snowflake without writing anything:
+#
+#   flowctl catalog test --source flow/materialization.flow.yaml
+#
+# Fill in your Snowflake account host, and paste the PKCS#8 private key you
+# generated in snowflake/setup.sql as `credentials.private_key`. Standard
+# updates (the default, `delta_updates: false`) keep the Snowflake table an
+# exact mirror of the Postgres table -- that mirror is what dbt reads as its
+# source.
+materializations:
+  yourprefix/agent-demo/destination-snowflake:
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/materialize-snowflake:v4
+        config:
+          host: "<account>.snowflakecomputing.com"
+          database: AGENT_DEMO
+          schema: PUBLIC
+          # `warehouse` is required unless the Snowflake user has a default
+          # warehouse set -- otherwise the connector fails with
+          # "no warehouse configured and default warehouse not set".
+          warehouse: AGENT_WH
+          role: AGENT_ROLE
+          timestamp_type: TIMESTAMP_LTZ
+          credentials:
+            auth_type: jwt
+            user: AGENT_USER
+            private_key: |
+              -----BEGIN PRIVATE KEY-----
+              <contents of rsa_key.p8>
+              -----END PRIVATE KEY-----
+          syncSchedule:
+            syncFrequency: 5m
+    bindings:
+      - resource:
+          table: orders
+          delta_updates: false
+        source: yourprefix/agent-demo/public/orders

--- a/estuary-orchestra-agent-pipeline/generator/Dockerfile
+++ b/estuary-orchestra-agent-pipeline/generator/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.12-slim
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY . .
+
+CMD ["python", "-u", "generator.py"]

--- a/estuary-orchestra-agent-pipeline/generator/generator.py
+++ b/estuary-orchestra-agent-pipeline/generator/generator.py
@@ -1,0 +1,138 @@
+"""Continuously write realistic orders into Postgres.
+
+The generator simulates a live operational table so the CDC pipeline always has
+something to stream. Every tick it:
+
+  * inserts brand new orders,
+  * advances the status of recent orders (pending -> shipped -> delivered),
+  * occasionally deletes an order,
+
+so the capture sees inserts, updates, and deletes -- all three operations that
+real change data capture has to handle.
+
+Configuration comes from two environment variables:
+
+  DATABASE_URL      postgresql://user:pass@host:port/db
+  RATE_PER_SECOND   how many operations to perform per second (default: 2)
+"""
+
+import os
+import random
+import time
+
+import psycopg2
+from faker import Faker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgresql://postgres:postgres@localhost:5432/postgres"
+)
+RATE_PER_SECOND = float(os.getenv("RATE_PER_SECOND", "2"))
+
+# The lifecycle a real order moves through. We nudge recent orders one step
+# forward at a time so updates look believable.
+NEXT_STATUS = {
+    "pending": "shipped",
+    "shipped": "delivered",
+}
+
+fake = Faker()
+
+
+def connect():
+    """Connect to Postgres, retrying while the container finishes starting."""
+    while True:
+        try:
+            conn = psycopg2.connect(DATABASE_URL)
+            conn.autocommit = True
+            print("Connected to Postgres.", flush=True)
+            return conn
+        except psycopg2.OperationalError as exc:
+            print(f"Postgres not ready yet ({exc}); retrying in 2s...", flush=True)
+            time.sleep(2)
+
+
+def insert_order(cur):
+    cur.execute(
+        """
+        insert into public.orders (customer_name, amount, status)
+        values (%s, %s, 'pending')
+        returning order_id
+        """,
+        (fake.name(), round(random.uniform(5.0, 500.0), 2)),
+    )
+    order_id = cur.fetchone()[0]
+    print(f"insert  {order_id}", flush=True)
+
+
+def advance_order(cur):
+    """Move a recent, non-terminal order to its next status."""
+    cur.execute(
+        """
+        select order_id, status
+        from public.orders
+        where status in ('pending', 'shipped')
+        order by updated_at asc
+        limit 1
+        """
+    )
+    row = cur.fetchone()
+    if row is None:
+        return
+    order_id, status = row
+    cur.execute(
+        """
+        update public.orders
+        set status = %s, event_ts = now(), updated_at = now()
+        where order_id = %s
+        """,
+        (NEXT_STATUS[status], order_id),
+    )
+    print(f"update  {order_id} -> {NEXT_STATUS[status]}", flush=True)
+
+
+def delete_order(cur):
+    cur.execute("select order_id from public.orders order by random() limit 1")
+    row = cur.fetchone()
+    if row is None:
+        return
+    (order_id,) = row
+    cur.execute("delete from public.orders where order_id = %s", (order_id,))
+    print(f"delete  {order_id}", flush=True)
+
+
+def main():
+    conn = connect()
+    cur = conn.cursor()
+
+    interval = 1.0 / RATE_PER_SECOND if RATE_PER_SECOND > 0 else 0.5
+    print(f"Generating orders at ~{RATE_PER_SECOND}/s. Ctrl-C to stop.", flush=True)
+
+    try:
+        while True:
+            action = random.choices(
+                ["insert", "update", "delete"],
+                weights=[0.6, 0.3, 0.1],
+                k=1,
+            )[0]
+            try:
+                if action == "insert":
+                    insert_order(cur)
+                elif action == "update":
+                    advance_order(cur)
+                else:
+                    delete_order(cur)
+            except psycopg2.Error as exc:
+                print(f"Query failed ({exc}); reconnecting...", flush=True)
+                conn = connect()
+                cur = conn.cursor()
+
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        print("Stopping generator.", flush=True)
+    finally:
+        cur.close()
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/estuary-orchestra-agent-pipeline/generator/requirements.txt
+++ b/estuary-orchestra-agent-pipeline/generator/requirements.txt
@@ -1,0 +1,2 @@
+Faker==25.1.0
+psycopg2-binary==2.9.9

--- a/estuary-orchestra-agent-pipeline/orchestra/daily_orders_pipeline.yaml
+++ b/estuary-orchestra-agent-pipeline/orchestra/daily_orders_pipeline.yaml
@@ -1,0 +1,177 @@
+# daily_orders_pipeline.yaml
+#
+# This is the kind of pipeline the Orchestra `create-orchestra-pipeline` and
+# `write-snowflake-dq-tests` agent skills author for you. It orchestrates the
+# batch layer that sits on top of Estuary's real-time stream:
+#
+#   1. check_ingestion  -- is the Estuary pipeline actually healthy and fresh?
+#   2. transform        -- rebuild the dbt models over the streamed data
+#   3. quality_tests    -- assert the rebuilt marts are sane
+#
+# Stage 1 is the hinge between the two tools: Orchestra has a native ESTUARY
+# integration, so the batch layer refuses to transform stale or broken data
+# instead of silently publishing it.
+#
+# Replace `yourprefix` with your Estuary tenant prefix. Connections are
+# referenced as ${{ ENV.* }} environment variables -- configure them in the
+# Orchestra UI (Settings -> Connections, then Environments) rather than pasting
+# credentials into this file.
+version: v1
+name: 'Daily Orders Analytics #estuary #dbt #snowflake #dataquality'
+
+# Six-field cron, minute-first: 06:00 UTC daily, after a night of streamed
+# changes has landed.
+schedule:
+  - name: Daily 6am UTC
+    cron: 0 6 ? * * *
+    timezone: UTC
+
+pipeline:
+  check_ingestion:
+    name: Check Estuary ingestion
+    depends_on: []
+    tasks:
+      # ESTUARY_CHECK_FLOW reads the task's OpenMetrics endpoint and compares
+      # deltas since the last check. error_threshold: 0 means any new error
+      # fails the run; latency_threshold is seconds since the task last
+      # published data, so a stalled capture is caught here rather than
+      # surfacing as mysteriously stale dashboards.
+      #
+      # IMPORTANT: give latency_threshold real headroom. The reported metric
+      # tracks commit-round acknowledgement, NOT row freshness, so it runs much
+      # higher than actual data lag -- measured against a 5m syncFrequency it
+      # reported 694-945s while Snowflake was only ~9s behind Postgres. 900
+      # false-alarms; 1800 is a realistic floor for a 5m sync. If you leave the
+      # Snowflake connector on its 30m default, go higher still.
+      #
+      # Also note the first check has no prior sample to diff against, so it
+      # reports the task's whole failure history as "new". Expect run one to be
+      # noisy and judge from run two onward.
+      check_capture:
+        integration: ESTUARY
+        integration_job: ESTUARY_CHECK_FLOW
+        parameters:
+          task: yourprefix/agent-demo/source-postgres
+          error_threshold: 0
+          warn_threshold: 0
+          latency_threshold: 1800
+        depends_on: []
+        name: Check Postgres capture
+        connection: ${{ ENV.ESTUARY_CONNECTION }}
+
+      check_materialization:
+        integration: ESTUARY
+        integration_job: ESTUARY_CHECK_FLOW
+        parameters:
+          task: yourprefix/agent-demo/destination-snowflake
+          error_threshold: 0
+          warn_threshold: 0
+          latency_threshold: 1800
+        depends_on: []
+        name: Check Snowflake materialization
+        connection: ${{ ENV.ESTUARY_CONNECTION }}
+
+  transform:
+    name: Rebuild dbt models
+    depends_on: [check_ingestion]
+    tasks:
+      dbt_build:
+        integration: DBT_CORE
+        integration_job: DBT_CORE_EXECUTE
+        parameters:
+          # `commands` is a single string, not a list -- and note it really is
+          # ONE command: newlines get flattened into one shell invocation, so
+          # "dbt deps\ndbt build" runs as `dbt deps dbt build ...` and fails
+          # with "No such option '--select'".
+          #
+          # You don't need `dbt deps` anyway: Orchestra clones the repo and
+          # installs packages.yml dependencies itself before running this.
+          commands: dbt build --select stg_orders daily_order_metrics
+          # Path to the dbt project within the repo. "." when dbt_project.yml
+          # is at the repo root.
+          project_dir: "."
+          package_manager: PIP
+        depends_on: []
+        name: dbt build
+        connection: ${{ ENV.DBT_CONNECTION }}
+
+  quality_tests:
+    name: Snowflake data-quality tests
+    depends_on: [transform]
+    tasks:
+      # SNOWFLAKE_RUN_TEST runs the statement and counts the returned rows --
+      # each query is written so a non-empty result means "this is wrong".
+      # error_threshold_expression '> 0' turns any violating row into a failure.
+
+      # Freshness: has anything landed recently? Written as a HAVING so it
+      # returns exactly one row when the newest order is too old.
+      freshness:
+        integration: SNOWFLAKE
+        integration_job: SNOWFLAKE_RUN_TEST
+        parameters:
+          statement: >-
+            select max(updated_at) as newest
+            from AGENT_DEMO.ANALYTICS.STG_ORDERS
+            having max(updated_at) < dateadd('hour', -24, current_timestamp())
+          error_threshold_expression: '> 0'
+          warn_threshold_expression: '> 0'
+        depends_on: []
+        name: Orders are fresh
+        connection: ${{ ENV.SNOWFLAKE_CONNECTION }}
+
+      # Revenue sanity: no null or negative money in the published mart.
+      revenue_sane:
+        integration: SNOWFLAKE
+        integration_job: SNOWFLAKE_RUN_TEST
+        parameters:
+          statement: >-
+            select order_date, status, total_amount
+            from AGENT_DEMO.ANALYTICS.DAILY_ORDER_METRICS
+            where total_amount is null or total_amount < 0
+          error_threshold_expression: '> 0'
+          warn_threshold_expression: '> 0'
+        depends_on: []
+        name: Revenue is non-negative
+        connection: ${{ ENV.SNOWFLAKE_CONNECTION }}
+
+      # Status enum: the CDC stream should only ever carry these three values.
+      status_values:
+        integration: SNOWFLAKE
+        integration_job: SNOWFLAKE_RUN_TEST
+        parameters:
+          statement: >-
+            select distinct status
+            from AGENT_DEMO.ANALYTICS.STG_ORDERS
+            where status not in ('pending', 'shipped', 'delivered')
+          error_threshold_expression: '> 0'
+          warn_threshold_expression: '> 0'
+        depends_on: []
+        name: Status values are known
+        connection: ${{ ENV.SNOWFLAKE_CONNECTION }}
+
+      # No future-dated events -- a classic sign of a broken source clock.
+      no_future_events:
+        integration: SNOWFLAKE
+        integration_job: SNOWFLAKE_RUN_TEST
+        parameters:
+          statement: >-
+            select order_id, event_ts
+            from AGENT_DEMO.ANALYTICS.STG_ORDERS
+            where event_ts > current_timestamp()
+          error_threshold_expression: '> 0'
+          warn_threshold_expression: '> 0'
+        depends_on: []
+        name: No future-dated orders
+        connection: ${{ ENV.SNOWFLAKE_CONNECTION }}
+
+# Alerting. Uncomment once you've added a Slack connection in the Orchestra UI
+# and filled in its connection_id -- validation rejects a SLACK destination when
+# the account has no default Slack connection.
+#
+# alerts:
+#   - name: On Failure
+#     statuses: [FAILED, WARNING]
+#     destinations:
+#       - integration: SLACK
+#         destination: '#data-alerts'
+#         connection_id: <your-slack-connection-id>

--- a/estuary-orchestra-agent-pipeline/postgres/init.sql
+++ b/estuary-orchestra-agent-pipeline/postgres/init.sql
@@ -1,0 +1,47 @@
+-- init.sql
+-- Runs automatically the first time the Postgres container starts.
+-- It prepares the database for Estuary CDC and creates the orders table
+-- that the traffic generator writes to. This is the operational source that
+-- the Estuary agent skills will capture and stream into Snowflake.
+
+-- ---------------------------------------------------------------------------
+-- The table we capture from.
+-- event_ts records when each change happened, which lets the dbt models and
+-- Orchestra quality checks reason about freshness later.
+-- ---------------------------------------------------------------------------
+create table if not exists public.orders (
+  order_id      uuid primary key default gen_random_uuid(),
+  customer_name text not null,
+  amount        numeric(10,2) not null,
+  status        text not null default 'pending',
+  event_ts      timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+);
+
+-- ---------------------------------------------------------------------------
+-- CDC prerequisites for Estuary.
+-- ---------------------------------------------------------------------------
+
+-- A dedicated user with replication rights. The replication role lets the
+-- connector create and read from a replication slot, which is Postgres's way
+-- of holding your place in the WAL so no changes are discarded before you've
+-- read them.
+create user flow_capture with password 'secret' replication;
+grant pg_read_all_data to flow_capture;
+
+-- A watermarks table the connector uses to coordinate a precise
+-- backfill-to-streaming handoff. The connector writes marker values into it
+-- during backfill so it can stitch the snapshot and the live stream together
+-- without gaps or overlaps.
+create table if not exists public.flow_watermarks (
+  slot text primary key,
+  watermark text
+);
+grant all privileges on table public.flow_watermarks to flow_capture;
+
+-- A publication: the allowlist of tables whose changes are exposed. Only
+-- tables added here emit changes, so you capture exactly what you intend to.
+create publication flow_publication
+  for table public.orders, public.flow_watermarks;
+alter publication flow_publication
+  set (publish_via_partition_root = true);

--- a/estuary-orchestra-agent-pipeline/snowflake/setup.sql
+++ b/estuary-orchestra-agent-pipeline/snowflake/setup.sql
@@ -19,6 +19,7 @@ create role if not exists identifier($svc_role);
 grant role identifier($svc_role) to role SYSADMIN;
 
 create user if not exists identifier($svc_user)
+  type = service
   default_role = $svc_role
   default_warehouse = $warehouse_name;
 grant role identifier($svc_role) to user identifier($svc_user);

--- a/estuary-orchestra-agent-pipeline/snowflake/setup.sql
+++ b/estuary-orchestra-agent-pipeline/snowflake/setup.sql
@@ -1,0 +1,67 @@
+-- setup.sql
+-- Run this in a Snowflake worksheet (as a role that can create databases,
+-- roles, users, and warehouses, e.g. ACCOUNTADMIN) to create the shared
+-- environment used by BOTH tools in this demo:
+--
+--   * Estuary materializes the streamed orders into AGENT_DEMO.PUBLIC.ORDERS
+--   * Orchestra runs dbt + quality tests, writing models into AGENT_DEMO.ANALYTICS
+--
+-- One database, one warehouse, one service user keeps the demo cheap and simple.
+
+set database_name  = 'AGENT_DEMO';
+set warehouse_name = 'AGENT_WH';
+set svc_role       = 'AGENT_ROLE';
+set svc_user       = 'AGENT_USER';
+
+begin;
+
+create role if not exists identifier($svc_role);
+grant role identifier($svc_role) to role SYSADMIN;
+
+create user if not exists identifier($svc_user)
+  default_role = $svc_role
+  default_warehouse = $warehouse_name;
+grant role identifier($svc_role) to user identifier($svc_user);
+
+-- An XS warehouse is plenty: continuous CDC merges are small and frequent, and
+-- the daily dbt run is light. auto_suspend = 60 stops the warehouse after a
+-- minute of inactivity so you pay nothing between syncs; auto_resume wakes it.
+create warehouse if not exists identifier($warehouse_name)
+  warehouse_size = xsmall
+  auto_suspend   = 60
+  auto_resume    = true
+  initially_suspended = true;
+grant usage on warehouse identifier($warehouse_name)
+  to role identifier($svc_role);
+
+create database if not exists identifier($database_name);
+grant ownership on database identifier($database_name)
+  to role identifier($svc_role);
+
+commit;
+
+-- PUBLIC is where Estuary lands raw orders; ANALYTICS is where dbt builds.
+--
+-- Both must exist before you publish the materialization: the Snowflake
+-- connector creates *tables*, not schemas, so a missing schema surfaces later as
+--   Schema 'AGENT_DEMO.PUBLIC' does not exist or not authorized
+-- on the connector's first commit rather than at validation time.
+use role identifier($svc_role);
+create schema if not exists identifier($database_name).PUBLIC;
+create schema if not exists identifier($database_name).ANALYTICS;
+
+-- ---------------------------------------------------------------------------
+-- Key-pair authentication (recommended; Snowflake is phasing out passwords for
+-- programmatic access). Estuary and Orchestra both authenticate as AGENT_USER.
+-- Generate a key pair locally:
+--
+--   openssl genrsa 2048 | openssl pkcs8 -topk8 -inform PEM \
+--     -out rsa_key.p8 -nocrypt
+--   openssl rsa -in rsa_key.p8 -pubout -out rsa_key.pub
+--
+-- Then attach the public key to the user (paste the contents of rsa_key.pub
+-- without the header/footer lines), and keep rsa_key.p8 for the connector
+-- configs.
+-- ---------------------------------------------------------------------------
+-- alter user AGENT_USER
+--   set rsa_public_key = '<contents of rsa_key.pub, without header lines>';


### PR DESCRIPTION
Demo of the Estuary and Orchestra agent skills working together to build a data pipeline from natural-language prompts.

Estuary streams Postgres CDC into Snowflake in real time; Orchestra runs the scheduled dbt transform and Snowflake data-quality tests on top. The two are wired together rather than merely adjacent — Orchestra's native `ESTUARY_CHECK_FLOW` gates the batch layer on ingestion health, so a stalled capture skips the dbt build instead of quietly rebuilding marts on stale data.

Built and run end to end, so the connector configs, pipeline YAML, and dbt models reflect what the live APIs actually accept. Gotchas that cost real debugging time are annotated inline and summarised in the README (sops MAC covering plaintext config fields, `DBT_CORE_EXECUTE.commands` flattening newlines into one command, the Estuary latency metric tracking commit acknowledgement rather than row freshness).

Contents: Dockerized Postgres + CDC traffic generator, Snowflake setup SQL, Estuary capture and materialization specs, a dbt project, and the Orchestra pipeline YAML.